### PR TITLE
Moved supertest to devDependencies, supertest module won't be needed …

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
     "morgan": "^1.7.0",
-    "pg": "^6.1.0",
+    "pg": "^6.1.0"
+  },
+  "devDependencies": {
     "supertest": "^2.0.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"


### PR DESCRIPTION
…in production nodes

npm install                          ---> installs package.json's dependencies and devDependencies
npm install --production    ---> installs only dependencies (our autospinup script will run this)